### PR TITLE
Feat/feedback improvements

### DIFF
--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -33,7 +33,7 @@ export const Footer = () => {
           <div className="flex justify-center items-center gap-2 text-sm w-full">
             <div className="text-center">
               <a
-                href="https://github.com/scaffold-eth/se-2"
+                href="https://github.com/Kryha/scaffold-eth-2-noir"
                 target="_blank"
                 rel="noreferrer"
                 className="underline underline-offset-2"
@@ -52,19 +52,12 @@ export const Footer = () => {
                   className="underline underline-offset-2"
                 >
                   BuidlGuidl
+                </a>{" "}
+                and{" "}
+                <a href="https://kryha.io/" target="_blank" rel="noreferrer" className="underline underline-offset-2">
+                  Kryha
                 </a>
               </p>
-            </div>
-            <span>·</span>
-            <div className="text-center">
-              <a
-                href="https://t.me/joinchat/KByvmRe5wkR-8F_zz6AjpA"
-                target="_blank"
-                rel="noreferrer"
-                className="underline underline-offset-2"
-              >
-                Support
-              </a>
             </div>
           </div>
         </ul>

--- a/packages/nextjs/pages/age-restricted-example/AgeRestrictedContractExecutor.tsx
+++ b/packages/nextjs/pages/age-restricted-example/AgeRestrictedContractExecutor.tsx
@@ -1,16 +1,33 @@
+import { useState } from "react";
 import { CodeText } from "./CodeText";
-import { useScaffoldContractWrite } from "~~/hooks/scaffold-eth";
+import { useScaffoldContractRead, useScaffoldContractWrite } from "~~/hooks/scaffold-eth";
 import { useBirthYearProofsStore } from "~~/services/store/birth-year-proofs";
+
+export const BalloonCount = (props: { sender: string }) => {
+  const { data } = useScaffoldContractRead({
+    contractName: "BalloonToken",
+    functionName: "balanceOf",
+    args: [props.sender],
+  });
+
+  if (data?.toString()) {
+    return <p>Balloon count: {data?.toString()}</p>;
+  }
+
+  return <></>;
+};
 
 export const AgeRestrictedContractExecutor = () => {
   const proof = useBirthYearProofsStore(state => state.proof);
   const setProof = useBirthYearProofsStore(state => state.setProof);
+  const [sender, setSender] = useState("");
 
   const { writeAsync, isLoading } = useScaffoldContractWrite({
     contractName: "BalloonVendor",
     functionName: "getFreeToken",
     args: [proof],
     onBlockConfirmation: txnReceipt => {
+      setSender(txnReceipt.from);
       console.log("📦 Transaction blockHash", txnReceipt.blockHash);
     },
   });
@@ -47,6 +64,7 @@ export const AgeRestrictedContractExecutor = () => {
       <div>
         <div className="card w-full shadow-2xl bg-base-100">
           <div className="card-body">
+            <BalloonCount sender={sender} />
             <div className="form-control">
               <label className="label">
                 <span className="label-text">Your proof of having the required birth year ✅</span>

--- a/packages/nextjs/pages/age-restricted-example/AgeRestrictedContractExecutor.tsx
+++ b/packages/nextjs/pages/age-restricted-example/AgeRestrictedContractExecutor.tsx
@@ -18,7 +18,7 @@ export const AgeRestrictedContractExecutor = () => {
   return (
     <div className="grid grid-cols-2 gap-6 max-w-7xl">
       <div>
-        <h1 className="text-3xl font-bold">Step 3: Getting the balloon🎈 NFT</h1>
+        <h1 className="text-3xl font-bold">Step 3: Getting the balloon 🎈</h1>
         <p>
           The ballon store is using the same <CodeText text="TokenVendor.sol" /> contract as the{" "}
           <a className="link" href="https://speedrunethereum.com/challenge/token-vendor">

--- a/packages/nextjs/pages/age-restricted-example/AgeRestrictedContractExecutor.tsx
+++ b/packages/nextjs/pages/age-restricted-example/AgeRestrictedContractExecutor.tsx
@@ -78,7 +78,7 @@ export const AgeRestrictedContractExecutor = () => {
               />
             </div>
             <button className="btn btn-primary mt-6" onClick={() => writeAsync()} disabled={isLoading}>
-              Get free balloon 🎈
+              Get balloon 🎈
             </button>
           </div>
         </div>

--- a/packages/nextjs/pages/age-restricted-example/AgeRestrictedContractExecutor.tsx
+++ b/packages/nextjs/pages/age-restricted-example/AgeRestrictedContractExecutor.tsx
@@ -62,7 +62,7 @@ export const AgeRestrictedContractExecutor = () => {
         </p>
       </div>
       <div>
-        <div className="card w-full shadow-2xl bg-base-100">
+        <div className="card w-full shadow-2xl bg-base-300">
           <div className="card-body">
             <BalloonCount sender={sender} />
             <div className="form-control">
@@ -77,7 +77,7 @@ export const AgeRestrictedContractExecutor = () => {
                 onChange={e => setProof(e.target.value as `0x${string}`)}
               />
             </div>
-            <button className="btn btn-secondary mt-6" onClick={() => writeAsync()} disabled={isLoading}>
+            <button className="btn btn-primary mt-6" onClick={() => writeAsync()} disabled={isLoading}>
               Get free balloon 🎈
             </button>
           </div>

--- a/packages/nextjs/pages/age-restricted-example/BirthDateSignature.tsx
+++ b/packages/nextjs/pages/age-restricted-example/BirthDateSignature.tsx
@@ -68,7 +68,7 @@ export const BirthDateSignature = ({ aliceDefaultAge }: { aliceDefaultAge: numbe
         <p>
           Alice recognizes that, in order for her to not have to share her age with the balloon store, she at least has
           to share her age with a trusted third party. In this case, the balloon store has selected the Town Hall to be
-          the trusted third party🏛. Alice accepts the fact that she has to share her age with the Town Hall.
+          the trusted third party 🏛. Alice accepts the fact that she has to share her age with the Town Hall.
         </p>
         <p>
           When the balloon store implemented their zero knowledge proof solution they made sure that they are using the
@@ -117,7 +117,7 @@ export const BirthDateSignature = ({ aliceDefaultAge }: { aliceDefaultAge: numbe
             </div>
             <div className="form-control">
               <label className="label">
-                <span className="label-text">Third party&apos;s🏛 private key for signing</span>
+                <span className="label-text">Third party&apos;s 🏛 private key for signing</span>
               </label>
               <input
                 type="text"

--- a/packages/nextjs/pages/age-restricted-example/BirthDateSignature.tsx
+++ b/packages/nextjs/pages/age-restricted-example/BirthDateSignature.tsx
@@ -90,7 +90,7 @@ export const BirthDateSignature = ({ aliceDefaultAge }: { aliceDefaultAge: numbe
         </p>
       </div>
       <div>
-        <div className="card w-full shadow-2xl bg-base-100">
+        <div className="card w-full shadow-2xl bg-base-300">
           <div className="card-body">
             <div className="form-control">
               <label className="label">
@@ -128,7 +128,7 @@ export const BirthDateSignature = ({ aliceDefaultAge }: { aliceDefaultAge: numbe
               />
             </div>
             <div className="form-control">
-              <button className="btn btn-secondary mt-6" onClick={handleSubmission}>
+              <button className="btn btn-primary mt-6" onClick={handleSubmission}>
                 Sign birth year 📜
               </button>
             </div>

--- a/packages/nextjs/pages/age-restricted-example/GenerateProof.tsx
+++ b/packages/nextjs/pages/age-restricted-example/GenerateProof.tsx
@@ -128,7 +128,7 @@ export const GenerateProof = ({ requiredBirthYear }: { requiredBirthYear: number
         </p>
       </div>
       <div>
-        <div className="card w-full shadow-2xl bg-base-100">
+        <div className="card w-full shadow-2xl bg-base-300">
           <div className="card-body">
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 sm:gap-8">
               <div className="form-control">
@@ -194,7 +194,7 @@ export const GenerateProof = ({ requiredBirthYear }: { requiredBirthYear: number
               />
             </div>
             <div className="form-control mt-6">
-              <button className="btn btn-secondary" onClick={handleSubmission} disabled={isProofRunning}>
+              <button className="btn btn-primary" onClick={handleSubmission} disabled={isProofRunning}>
                 Generate proof ✅
               </button>
             </div>

--- a/packages/nextjs/pages/age-restricted-example/ZkSteps.tsx
+++ b/packages/nextjs/pages/age-restricted-example/ZkSteps.tsx
@@ -43,7 +43,7 @@ const ZkSteps: NextPage = () => {
           <ul className="steps pt-12 steps-vertical md:steps-horizontal">
             <li className="step step-primary">Third party signature 🏛📜</li>
             <li className={`step ${step2ClassName}`}>Generate proof ✅</li>
-            <li className={`step ${step3ClassName}`}>Call contract🎈</li>
+            <li className={`step ${step3ClassName}`}>Call contract 🎈</li>
           </ul>
           <div className="join grid grid-cols-2 mt-8 gap-8">
             <>

--- a/packages/nextjs/pages/age-restricted-example/ZkStepsIntro.tsx
+++ b/packages/nextjs/pages/age-restricted-example/ZkStepsIntro.tsx
@@ -9,7 +9,7 @@ export const ZkStepsIntro = ({ setCurrentStep, yearTenYearsAgo }: ZkStepsIntroPr
       <div className="hero-content text-center">
         <div className="max-w-3xl">
           <div className="flex flex-col justify-center items-center">
-            <h1 className="text-5xl font-bold">Hello there</h1>
+            <h1 className="text-5xl font-bold">ZK Age Restriction</h1>
             <p className="py-6 text-left">
               Alice has heard that balloon store in town is handing out balloons 🎈 to anyone who is 10 years old or
               younger. However, Alice does not want to share her age with anyone. Lucky for her, the balloon store has a

--- a/packages/nextjs/pages/age-restricted-example/ZkStepsIntro.tsx
+++ b/packages/nextjs/pages/age-restricted-example/ZkStepsIntro.tsx
@@ -10,26 +10,26 @@ export const ZkStepsIntro = ({ setCurrentStep, yearTenYearsAgo }: ZkStepsIntroPr
         <div className="max-w-3xl">
           <div className="flex flex-col justify-center items-center">
             <h1 className="text-5xl font-bold">Hello there</h1>
-            <p className="py-6">
-              Alice has heard that balloon store in town is handing out balloons🎈 to anyone who is 10 years old or
+            <p className="py-6 text-left">
+              Alice has heard that balloon store in town is handing out balloons 🎈 to anyone who is 10 years old or
               younger. However, Alice does not want to share her age with anyone. Lucky for her, the balloon store has a
-              zero knowledge proof solution. This means she can claim her balloon🎈 and only share as little information
-              as necessary publicly. Here is how she would go about it...
+              zero knowledge proof solution. This means she can claim her balloon 🎈 and only share as little
+              information as necessary publicly. Here is how she would go about it...
               <br />
             </p>
             <ol className="list-decimal list-inside text-left">
               {/* When the list is centered it looks weird, but perhaps there is another solution than `text-left`?*/}
               <li>
-                First, she needs to find a trusted third party🏛 that can give her an official signature📜 that she is
+                First, she needs to find a trusted third party 🏛 that can give her an official signature 📜 that she is
                 born in a specific year.
               </li>
               <li>
-                Then, she needs to generate a zero knowledge proof✅. It should prove that the signed birth year is
-                greater than or equal to {yearTenYearsAgo} and that the signature📜 is done by a known public key.
+                Then, she needs to generate a zero knowledge proof ✅. It should prove that the signed birth year is
+                greater than or equal to {yearTenYearsAgo} and that the signature 📜 is done by a known public key.
               </li>
               <li>
-                Finally, Alice can call the balloon store&apos;s age restricted contract with her proof✅ and get a
-                balloon🎈.
+                Finally, Alice can call the balloon store&apos;s age restricted contract with her proof ✅ and get a
+                balloon 🎈.
               </li>
             </ol>
           </div>

--- a/packages/nextjs/tailwind.config.js
+++ b/packages/nextjs/tailwind.config.js
@@ -36,7 +36,7 @@ module.exports = {
         darkTheme: {
           primary: "#231735",
           "primary-content": "#F0F0F0",
-          secondary: "#2F1F49",
+          secondary: "#523B78",
           "secondary-content": "#F0F0F0",
           accent: "#99A5EE",
           "accent-content": "#231735",
@@ -44,7 +44,7 @@ module.exports = {
           "neutral-content": "#231735",
           "base-100": "#231735",
           "base-200": "#231735",
-          "base-300": "#2F1F49",
+          "base-300": "#523B78",
           "base-content": "#F0F0F0",
           info: "#231735",
           success: "#34EEB6",


### PR DESCRIPTION
[x] Add Kryha links in the footer
[x] Update age restricted example page Title to “ZK Age Restriction”
[x] Make main description paragraph left aligned (instead of centerd)
[x] Add space between each icon and the previous word
[x] For dark theme, update card background (and buttons) color for a brighter purple (check Aztec branding) so that we have a better contrast ratio between elements and background
[x] In the last step, add a Ballon Icon somewhere after finalising the “Get Free Ballon” Action.
[x] Remove the “Free” word, since it can be miss-leading. Let the button read “Get Ballon”

<img width="1460" alt="Screenshot 2023-09-06 at 20 48 41" src="https://github.com/Kryha/scaffold-eth-2-noir/assets/41080133/09e2c5b3-5594-4099-8db1-4838c197d78b">
<img width="1453" alt="Screenshot 2023-09-06 at 20 48 58" src="https://github.com/Kryha/scaffold-eth-2-noir/assets/41080133/c34d558d-fdd3-41a9-bbed-e302fb8d7b69">

